### PR TITLE
Fix container image's registry name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,6 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GHCR
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -34,9 +33,7 @@ jobs:
         id: image_metadata # you'll use this in the next step
         uses: docker/metadata-action@v5
         with:
-          # list of Docker images to use as base name for tags
-          images: |
-            iombian-button-handler
+          images: ghcr.io/${{ github.repository }}
           # Docker tags based on the following events/attributes
           tags: |
             type=semver,pattern={{version}}
@@ -45,7 +42,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: True
+          push: true
           platforms: linux/amd64,linux/arm/v7
           tags: ${{ steps.image_metadata.outputs.tags }}
           labels: ${{ steps.image_metadata.outputs.labels }}


### PR DESCRIPTION
This pull request adds the container registry name to the final image name. This avoids any authorization error when pushing the image with GitHub Actions.

Signed-off-by: Aitor Iturrioz <aiturrioz@tknika.eus>