### PR TITLE
Remove branch from github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,6 @@ name: Build
 on:
   workflow_dispatch:
   push:
-    branches:
-      - 'main'
     tags:
       - 'v*.*.*'
 


### PR DESCRIPTION
Remove branch from github action so an image can be created from any branch when pushing a tag.